### PR TITLE
Add `--license` option to `ace format`

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -61,6 +61,7 @@ program
   .description('run formatter')
   .option('-m, --modified', 'only run against modified code')
   .option('-w, --write', 'fix errors that are found')
+  .option('-l, --license <path-to-license-file>', 'path to license file')
   .action(wrap('./lib/format'))
 
 program

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,14 +1,3 @@
-/**
- * Copyright (c) Codice Foundation
- *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
- * <http://www.gnu.org/licenses/lgpl.html>.
- *
- **/
 'use strict'
 
 // Based on similar script in Facebook/React
@@ -24,7 +13,7 @@ const prettierrc = require('../prettierrc')
 const listChangedFiles = require('./listChangedFiles')
 
 module.exports = async ({ args }) => {
-  const { write = false, modified = false } = args
+  const { write = false, modified = false, license = false } = args
   const changedFiles = modified ? listChangedFiles() : null
   const warnings = []
   const errors = []
@@ -93,17 +82,54 @@ module.exports = async ({ args }) => {
     })
   }
 
+  const toJavaDoc = function(str) {
+    if (str == '') return ''
+
+    let res = '/**\n'
+    str.split('\n').forEach(function(line) {
+      line = line.trim()
+      let prefix = ' *'
+      if (line != '') prefix += ' '
+      res += prefix + line + '\n'
+    })
+
+    return res + ' *\n **/\n'
+  }
+
+  let licenseHeader = ''
+  if (license) {
+    if (fs.existsSync(license)) {
+      licenseHeader = toJavaDoc(fs.readFileSync(license, 'utf8').toString())
+    } else {
+      error(`license file ${license} was not found.`)
+    }
+  }
+
   function processFile(file, index, files) {
     spinner.text = `${(((index + 1) / files.length) * 100).toFixed(0)}%`
     const options = getPrettierOptionsForFile(file)
     try {
       const input = fs.readFileSync(file, 'utf8')
+      const isMissingLicense =
+        (file.endsWith('.ts') ||
+          file.endsWith('.tsx') ||
+          file.endsWith('.js')) &&
+        licenseHeader != '' &&
+        !input.includes(licenseHeader)
       if (write) {
-        const output = prettier.format(input, options)
+        let output = prettier.format(input, options)
+        if (isMissingLicense) {
+          output = licenseHeader + output
+        }
         if (output !== input) {
           fs.writeFileSync(file, output, 'utf8')
         }
       } else {
+        if (isMissingLicense) {
+          warnings.push(
+            color.yellow(`\n${file}\n=> is missing the license header`)
+          )
+        }
         if (!prettier.check(input, options)) {
           warn(file)
         }
@@ -115,7 +141,7 @@ module.exports = async ({ args }) => {
 
   function getFilesToCheck() {
     return glob
-      .sync('**/*+(.tsx|.js|.less|.json|.css)', {
+      .sync('**/*+(.ts|.tsx|.js|.less|.json|.css)', {
         ignore: [
           '**/node_modules/**',
           '**/target/**',

--- a/lib/listChangedFiles.js
+++ b/lib/listChangedFiles.js
@@ -1,14 +1,3 @@
-/**
- * Copyright (c) Codice Foundation
- *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
- * <http://www.gnu.org/licenses/lgpl.html>.
- *
- **/
 'use strict'
 
 // Based on similar script in Facebook/React


### PR DESCRIPTION
Add `--license` option to `ace format`

- accepts license file path as an argument