### PR TITLE
Change useEslintrc to true so that subprojects can specify their own…

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -53,7 +53,7 @@ const htmlLint = () => {
 
 module.exports = ({ args }) => {
   const cli = new CLIEngine({
-    useEslintrc: false,
+    useEslintrc: true,
     rules: {
       'no-console': 'off',
       '@connexta/connexta/no-absolute-urls': 2,
@@ -77,6 +77,7 @@ module.exports = ({ args }) => {
       parser: 'babel-eslint',
     },
   })
+  console.log('running eslint cli')
   const report = cli.executeOnFiles(['./'])
   const formatter = cli.getFormatter()
   if (report.errorCount) {


### PR DESCRIPTION
… rules to use with `ace lint`. also, add a log statement "running eslint cli" to clarify that any output is from eslint