### PR TITLE
Remove node_modules from dev server ignored files

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -325,7 +325,6 @@ const prod = (base, { main }) =>
 
 const devServer = ({ auth, target, publicPath }) => ({
   watchOptions: {
-    ignored: /node_modules/,
     poll: 1000,
   },
   publicPath,


### PR DESCRIPTION
### Issue
Projects that have dependencies on upstream modules (where the code lives in node_modules) do not refresh the dev server when the upstream module gets updated.

### Testing Instructions
In a project that uses `ace`, edit a file in `node_modules` and watch the dev server update.

To test a PR of ace, update the dependency location in your `package.json` like so: 
```json
"@connexta/ace": "Bdthomson/ace#dev-server-ignored",
```