### PR TITLE
move eslint settings into a file so downstream projects can reference them

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+  rules: {
+    'no-console': 'off',
+    '@connexta/connexta/no-absolute-urls': 2,
+  },
+  globals: {
+    "define": "writable",
+  },
+  env: {
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  settings: {
+    react: { version: 'detect' },
+  },
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+  plugins: ['react', '@connexta/connexta'],
+  parser: 'babel-eslint',
+}

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -2,6 +2,7 @@ const CLIEngine = require('eslint').CLIEngine
 const cheerio = require('cheerio')
 const glob = require('glob')
 const fs = require('fs')
+const baseConfig = require('../.eslintrc.js')
 
 const htmlLint = () => {
   var htmlResults = { errorCount: 0, errors: [] }
@@ -54,28 +55,7 @@ const htmlLint = () => {
 module.exports = ({ args }) => {
   const cli = new CLIEngine({
     useEslintrc: true,
-    rules: {
-      'no-console': 'off',
-      '@connexta/connexta/no-absolute-urls': 2,
-    },
-    globals: ['define'],
-    envs: ['browser', 'node', 'mocha'],
-    baseConfig: {
-      extends: [
-        //'eslint:recommended',
-        //'plugin:react/recommended',
-      ],
-      settings: {
-        react: { version: 'detect' },
-      },
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        ecmaFeatures: { jsx: true },
-      },
-      plugins: ['react', '@connexta/connexta'],
-      parser: 'babel-eslint',
-    },
+    baseConfig,
   })
   console.log('running eslint cli')
   const report = cli.executeOnFiles(['./'])


### PR DESCRIPTION
fixes #14 
note that this changes the precedence of these settings: 

> baseConfig - Can optionally be set to a config object that has the same schema as .eslintrc.*. This will used as a default config, and will be merged with any configuration defined in .eslintrc.* files, with the .eslintrc.* files having precedence.

https://eslint.org/docs/developer-guide/nodejs-api#cliengine

because downstream projects often define `rules` of their own, they will need to now also manually specify: 
```
    'no-console': 'off',
    '@connexta/connexta/no-absolute-urls': 'error',
```