### PR TITLE
Generalize webpack build exclusions into a whitelist

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -46,6 +46,26 @@ const babelLoader = (plugins = []) => ({
   },
 })
 
+const packageWhitelist = ['catalog-ui-search', 'imperio', '@connexta']
+
+const includeInWebpackBuild = modulePath => {
+  // Include files not in node_modules
+  if (!modulePath.includes('node_modules')) {
+    return true
+  }
+
+  // Include files in whitelisted packages
+  return packageWhitelist.some(pkg => {
+    return (
+      modulePath.includes(pkg) &&
+      // Don't include items in nested node_modules
+      !modulePath.includes(pkg + '/node_modules')
+    )
+  })
+}
+
+const excludeFromWebpackBuild = modulePath => !includeInWebpackBuild(modulePath)
+
 const base = ({ alias = {}, env, tsTranspileOnly }) => ({
   entry: [nodeResolve('babel-polyfill'), nodeResolve('whatwg-fetch')],
   output: {
@@ -103,18 +123,7 @@ const base = ({ alias = {}, env, tsTranspileOnly }) => ({
       },
       {
         test: /\.jsx?$/,
-        exclude: function(modulePath) {
-          if (modulePath.indexOf('catalog-ui-search') > -1) {
-            if (
-              modulePath.lastIndexOf('node_modules') >
-              modulePath.lastIndexOf('catalog-ui-search')
-            ) {
-              return true
-            }
-            return false
-          }
-          return modulePath.indexOf('node_modules') > -1
-        },
+        exclude: excludeFromWebpackBuild,
         use: babelLoader(
           env === 'test'
             ? [
@@ -183,18 +192,7 @@ const base = ({ alias = {}, env, tsTranspileOnly }) => ({
             },
           },
         ],
-        exclude: function(modulePath) {
-          if (modulePath.indexOf('catalog-ui-search') > -1) {
-            if (
-              modulePath.lastIndexOf('node_modules') >
-              modulePath.lastIndexOf('catalog-ui-search')
-            ) {
-              return true
-            }
-            return false
-          }
-          return modulePath.indexOf('node_modules') > -1
-        },
+        exclude: excludeFromWebpackBuild,
       },
       {
         test: /\.(html)$/,


### PR DESCRIPTION
- Maintains `catalog-ui-search` as part of the whitelist
- Adds `imperio` to the whitelist for temporary use, should be migrated
  to `@connexta/imperio`.
- Adds a general rule to include `@connexta` packages