### PR TITLE
Adds support for workspaces with hoisting

### DIFF
--- a/lib/package-utils.js
+++ b/lib/package-utils.js
@@ -1,6 +1,15 @@
 const getWorkspaces = pkg => {
   const workspaces = []
-    .concat(pkg.workspaces ? pkg.workspaces : [])
+    .concat(
+      pkg.workspaces && pkg.workspaces.packages === undefined
+        ? pkg.workspaces
+        : []
+    )
+    .concat(
+      pkg.workspaces && pkg.workspaces.packages !== undefined
+        ? pkg.workspaces.packages
+        : []
+    )
     .concat(pkg.ace ? pkg.ace.features : [])
   return workspaces
 }


### PR DESCRIPTION
See https://yarnpkg.com/blog/2018/02/15/nohoist/

Example
```
"workspaces": {
  "packages": ["packages/*"],
  "nohoist": ["**/react-native", "**/react-native/**"]
}
```