### PR TITLE
Set all authentication types to BASIC

### DIFF
--- a/lib/disable-idp.js
+++ b/lib/disable-idp.js
@@ -60,7 +60,7 @@ module.exports = async ({ args }) => {
     )
     const [{ properties }] = configurations
 
-    properties.authenticationTypes = ('/=BASIC')
+    properties.authenticationTypes = (['/=BASIC'])
 
     const { whitelist: contextPath } = args
 

--- a/lib/disable-idp.js
+++ b/lib/disable-idp.js
@@ -60,7 +60,7 @@ module.exports = async ({ args }) => {
     )
     const [{ properties }] = configurations
 
-    properties.authenticationTypes = (['/=BASIC'])
+    properties.authenticationTypes = ['/=BASIC']
 
     const { whitelist: contextPath } = args
 

--- a/lib/disable-idp.js
+++ b/lib/disable-idp.js
@@ -60,8 +60,7 @@ module.exports = async ({ args }) => {
     )
     const [{ properties }] = configurations
 
-    properties.authenticationTypes.shift()
-    properties.authenticationTypes.unshift('/=BASIC')
+    properties.authenticationTypes = ('/=BASIC')
 
     const { whitelist: contextPath } = args
 


### PR DESCRIPTION
Without this, running dev servers in other web context policies like `/admin` were still being blocked.