### PR TITLE
Improve gen-feature to support non-root bundle

### DIFF
--- a/lib/gen-feature.js
+++ b/lib/gen-feature.js
@@ -36,12 +36,14 @@ const info = {
   groupId: 'project > groupId',
   artifactId: 'project > artifactId',
   version: 'project > parent > version',
+  packaging: 'project > packaging',
 }
 
 const jetty = {
   groupId: 'org.eclipse.jetty',
   artifactId: 'jetty-servlets',
   version: '9.2.19.v20160908',
+  packaging: 'bundle',
 }
 
 const extend = file => {
@@ -65,7 +67,11 @@ module.exports = ({ args, getPackage, getPom }) => {
   )
 
   const base =
-    args.extend !== undefined ? extend(args.extend) : [jetty, project].map(mvn)
+    args.extend !== undefined
+      ? extend(args.extend)
+      : [jetty, project]
+          .filter(({ packaging }) => packaging === 'bundle')
+          .map(mvn)
 
   const local = packages.map(({ name }) => ({
     groupId: project.groupId,

--- a/test/ace.spec.js
+++ b/test/ace.spec.js
@@ -94,7 +94,7 @@ describe('ace', () => {
   }).timeout(60000)
   it('ace test', async () => {
     equal(await ace('test', 'target/test/index.html'), 0)
-  })
+  }).timeout(60000)
   it('should tear down', async () => {
     await rimraf(root)
   })


### PR DESCRIPTION
gen-feature will now exclude the root module if is not a bundle.