### PR TITLE
Add package details as variable __package__

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -150,7 +150,11 @@ const base = ({
       /graphql-language-service-interface[\\/]dist$/,
       new RegExp(`^\\./.*\\.js$`)
     ),
-    new webpack.DefinePlugin({ ...gitEnv(), __ENV__: JSON.stringify(env) }),
+    new webpack.DefinePlugin({
+      ...gitEnv(),
+      __ENV__: JSON.stringify(env),
+      __package__json__: JSON.stringify(packageJson), // allow access to package json information, such as context path
+    }),
   ],
   externals: {
     'react/addons': true,


### PR DESCRIPTION
 - This is useful for applications relying on ace, and exposes possibilities like knowing the context-path.  If you know the context-path, you can account for reverse proxy usage.