### PR TITLE
Rename context-path to publicPath

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -122,7 +122,7 @@ program
     'set proxy target (default: https://localhost:8993)'
   )
   .option('--main <script>', 'the javascript entry file')
-  .option('--contextPath <path>', 'context path to start server on')
+  .option('--publicPath <path>', 'webpack public path to start server on')
   .option('--port <port>', 'dev server port (default: 8080)')
   .option('--host <host>', 'dev server host (default: localhost)')
   .option(

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -14,7 +14,7 @@ module.exports = ({ args, getPackage }) => {
     alias: pkg.alias,
     tsTranspileOnly: args.tsTranspileOnly === 'true',
     packageJson: pkg,
-    publicPath: pkg['context-path'],
+    publicPath: pkg['publicPath'],
   }
 
   const client = retrieveClientConfig(configuration)

--- a/lib/gen-feature.js
+++ b/lib/gen-feature.js
@@ -75,7 +75,7 @@ module.exports = ({ args, getPackage, getPom }) => {
   const project = extract(getPom(), info)
 
   const packages = ls(getWorkspaces(pkg)).filter(
-    pkg => pkg['context-path'] !== undefined
+    pkg => pkg['publicPath'] !== undefined
   )
 
   const base = getBaseCoordinates(args, project)

--- a/lib/package.js
+++ b/lib/package.js
@@ -53,7 +53,7 @@ Created-By: Apache Maven Bundle Plugin
 Import-Package: org.eclipse.jetty.servlets;version="[9.2.19, 9.2.19]"
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 Tool: Bnd-3.3.0.201609221906
-Web-ContextPath: ${pkg['context-path']}`,
+Web-ContextPath: ${pkg['publicPath']}`,
     { name: 'META-INF/MANIFEST.MF' }
   )
 

--- a/lib/pom.js
+++ b/lib/pom.js
@@ -60,7 +60,7 @@ module.exports = ({ args, getPackage, getPom }) => {
   const pom = getPom()
 
   const packages = ls(getWorkspaces(pkg)).filter(
-    pkg => pkg['context-path'] !== undefined
+    pkg => pkg['publicPath'] !== undefined
   )
 
   if (missingArtifacts(packages, pom) && !args.fix) {

--- a/lib/start.js
+++ b/lib/start.js
@@ -13,7 +13,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 module.exports = ({ args, getPackage }) => {
   const pkg = getPackage()
-  const publicPath = args.contextPath || pkg['context-path']
+  const publicPath = args.publicPath || pkg['publicPath']
 
   const main = args.main || pkg.main
   const env = process.env.NODE_ENV || args.env || 'development'

--- a/test/ace.spec.js
+++ b/test/ace.spec.js
@@ -32,7 +32,7 @@ const generateProject = opts => {
           name: 'example-project',
           license: 'MIT',
           main: 'src/main/webapp/index.js',
-          'context-path': './',
+          publicPath: './',
         },
         null,
         2


### PR DESCRIPTION
 Rename context-path to publicPath in order to be more transparent.