### PR TITLE
Updates gen-feature to allow an array of files to extend from, and to only filter exclusions from those files 

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -84,7 +84,11 @@ program
 program
   .command('gen-feature')
   .description('generate a feature file')
-  .option('-e, --extend <feature-file>', 'extend an existing feature file')
+  .option(
+    '-e, --extend [<feature-file>]',
+    'extend an existing feature file',
+    val => val.split(',')
+  )
   .option('-x, --exclude [projects]', 'exclude existing wabs', val =>
     val.split(',')
   )

--- a/lib/gen-feature.js
+++ b/lib/gen-feature.js
@@ -46,16 +46,20 @@ const jetty = {
   packaging: 'jar',
 }
 
-const extend = file => {
-  const features = fs.readFileSync(file, { encoding: 'utf8' })
-  const $ = cheerio.load(features, { xmlMode: true, decodeEntities: false })
-  return $('features > feature > bundle')
-    .map((i, el) =>
-      $(el)
-        .text()
-        .trim()
+const extend = files => {
+  return files.reduce((list, file) => {
+    const features = fs.readFileSync(file, { encoding: 'utf8' })
+    const $ = cheerio.load(features, { xmlMode: true, decodeEntities: false })
+    return list.concat(
+      $('features > feature > bundle')
+        .map((i, el) =>
+          $(el)
+            .text()
+            .trim()
+        )
+        .get()
     )
-    .get()
+  }, [])
 }
 
 const getBaseCoordinates = (args, project) => {

--- a/lib/gen-feature.js
+++ b/lib/gen-feature.js
@@ -92,12 +92,14 @@ module.exports = ({ args, getPackage, getPom }) => {
     version: project.version,
   }))
 
-  const coors = base.concat(local.map(mvn)).filter(coor => {
-    if (!Array.isArray(args.exclude)) {
-      return true
-    }
-    return !args.exclude.some(arg => coor.match(arg))
-  })
+  const coors = base
+    .filter(coor => {
+      if (!Array.isArray(args.exclude)) {
+        return true
+      }
+      return !args.exclude.some(arg => coor.match(arg))
+    })
+    .concat(local.map(mvn))
 
   const absolute = path.resolve('target/features.xml')
 


### PR DESCRIPTION
Slight updates to gen-feature to allow passing in multiple files to extend from, and to make it so we don't have to name bundles that are being replaced by local bundles differently (by making the filtering of exclusions only happen on the pass in files).
