### PR TITLE
ACE-79 Loosens version range restriction for org.eclipse.jetty.servlet package

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -50,7 +50,7 @@ Bundle-SymbolicName: ${pkg.name + '-wab'}
 Bundle-Vendor: ${pkg.author}
 Bundle-Version: ${version.replace('-', '.')}
 Created-By: Apache Maven Bundle Plugin
-Import-Package: org.eclipse.jetty.servlets;version="[9.2.19, 9.2.19]"
+Import-Package: org.eclipse.jetty.servlets;version="[9.2, 10.0)"
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 Tool: Bnd-3.3.0.201609221906
 Web-ContextPath: ${pkg['context-path']}`,


### PR DESCRIPTION
Fixes: #79 