### PR TITLE
long console.log messages are cut off when running with lerna. workar…

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -5,6 +5,15 @@ const {
   retrieveClientConfig,
 } = require('./webpack.config')
 
+const logWithWorkaround = message => {
+  // long console.log messages are cut off when running with lerna
+  // work around this by printing one line at time:
+  let lines = message.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    console.error(lines[i])
+  }
+}
+
 module.exports = ({ args, getPackage }) => {
   const pkg = getPackage()
 
@@ -29,9 +38,21 @@ module.exports = ({ args, getPackage }) => {
   }
 
   webpack(builds, (err, stats) => {
-    if (err || stats.hasErrors()) {
-      console.log(err || stats.toString())
+    if (err) {
+      logWithWorkaround(err.stack || err)
+      if (err.details) {
+        logWithWorkaround(err.details)
+      }
       process.exit(1)
+    }
+
+    if (stats.hasErrors()) {
+      logWithWorkaround(stats.toString())
+      process.exit(1)
+    }
+
+    if (stats.hasWarnings()) {
+      logWithWorkaround(stats.toString())
     }
   })
 }


### PR DESCRIPTION
…ound this by printing one line at time

if this is a lerna bug, it's still broken in the latest version I tried (3.20.2)