### PR TITLE
Support using flattened pom for repo's using revisions plugin.

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -11,10 +11,15 @@ const wrap = path => (args = {}) => {
 
   const getPackage = () => require(find.sync('package.json'))
   const getPom = () =>
-    cheerio.load(fs.readFileSync(find.sync('pom.xml'), { encoding: 'utf8' }), {
-      xmlMode: true,
-      decodeEntities: false,
-    })
+    cheerio.load(
+      fs.readFileSync(find.sync(['.flattened-pom.xml', 'pom.xml']), {
+        encoding: 'utf8',
+      }),
+      {
+        xmlMode: true,
+        decodeEntities: false,
+      }
+    )
 
   cmd({ args, getPackage, getPom })
 }


### PR DESCRIPTION
We switched some of our repos to use  revision plugin for releases see https://maven.apache.org/maven-ci-friendly.html the drawback is that the pom.xml doesn't have the version you have to grab the version from .flattend-pom.xml generated by this plugin https://www.mojohaus.org/flatten-maven-plugin/. This change just adds support for reading the .flattend-pom.xml