### PR TITLE
Update base to only include css less rule when not production

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -225,43 +225,6 @@ const base = ({
         },
       },
       {
-        test: /\.(css|less)$/,
-        oneOf: [
-          {
-            test: /\.tailwind\.css$/,
-            use: [
-              nodeResolve('style-loader'),
-              {
-                loader: nodeResolve('css-loader'),
-                options: { sourceMap: true },
-              },
-              {
-                loader: nodeResolve('postcss-loader'),
-                options: { sourceMap: true, exec: true },
-              },
-            ],
-          },
-          {
-            test: /\.(css|less)$/,
-            use: [
-              nodeResolve('style-loader'),
-              {
-                loader: nodeResolve('css-loader'),
-                options: { sourceMap: true },
-              },
-              {
-                loader: nodeResolve('postcss-loader'),
-                options: { sourceMap: true },
-              },
-              {
-                loader: nodeResolve('less-loader'),
-                options: { sourceMap: true },
-              },
-            ],
-          },
-        ],
-      },
-      {
         test: /\.unless$/,
         use: [
           nodeResolve('raw-loader'),
@@ -298,7 +261,49 @@ const base = ({
           loader: 'html-loader',
         },
       },
-    ],
+    ].concat(
+      env !== 'production'
+        ? [
+            {
+              test: /\.(css|less)$/,
+              oneOf: [
+                {
+                  test: /\.tailwind\.css$/,
+                  use: [
+                    nodeResolve('style-loader'),
+                    {
+                      loader: nodeResolve('css-loader'),
+                      options: { sourceMap: true },
+                    },
+                    {
+                      loader: nodeResolve('postcss-loader'),
+                      options: { sourceMap: true, exec: true },
+                    },
+                  ],
+                },
+                {
+                  test: /\.(css|less)$/,
+                  use: [
+                    nodeResolve('style-loader'),
+                    {
+                      loader: nodeResolve('css-loader'),
+                      options: { sourceMap: true },
+                    },
+                    {
+                      loader: nodeResolve('postcss-loader'),
+                      options: { sourceMap: true },
+                    },
+                    {
+                      loader: nodeResolve('less-loader'),
+                      options: { sourceMap: true },
+                    },
+                  ],
+                },
+              ],
+            },
+          ]
+        : []
+    ),
   },
   resolve: {
     alias: {
@@ -539,16 +544,6 @@ const prod = (base, { main, packageJson }) => {
     module: {
       rules: [
         {
-          test: /\.tailwind\.css$/,
-          loader: [
-            {
-              loader: nodeResolve('postcss-loader'),
-              options: { sourceMap: true, exec: true },
-            },
-          ],
-          enforce: 'pre',
-        },
-        {
           test: /\.(css|less)$/,
           oneOf: [
             {
@@ -650,8 +645,8 @@ const retrieveBaseConfig = opts => {
 }
 
 const retrieveClientConfig = opts => {
-  const baseConfig = retrieveBaseConfig(opts)
   const { main, packageJson, env = 'development' } = opts
+  const baseConfig = retrieveBaseConfig(opts)
   switch (env) {
     case 'production':
       return prod(baseConfig, { main, packageJson })


### PR DESCRIPTION
 - The css / less rule isn't correctly merged, so instead this will ensure it doesn't conflict and we accidentally use the style loader in production.