### PR TITLE
Explicitly set the node environment variable

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -16,9 +16,15 @@ const logWithWorkaround = (message) => {
 
 module.exports = ({ args, getPackage }) => {
   const pkg = getPackage()
+  const env = args.env || process.env.NODE_ENV || 'development'
+  /**
+   * Webpack does not set this, but the processes it calls (like tailwind) need it to be set.
+   * See https://github.com/webpack/webpack/issues/7074 for a long thread on this
+   */
+  process.env.NODE_ENV = env
 
   const configuration = {
-    env: args.env || process.env.NODE_ENV || 'development',
+    env,
     main: pkg.main,
     alias: pkg.alias,
     tsTranspileOnly: args.tsTranspileOnly === 'true',


### PR DESCRIPTION
 - Webpack does not set this, but the processes it calls (like tailwind) need it to be set.
 - See https://github.com/webpack/webpack/issues/7074 for a long thread on this