### PR TITLE
Reverts prettier endOfLine to previous default (pre version 2.0.0)

### DIFF
--- a/prettierrc.js
+++ b/prettierrc.js
@@ -2,4 +2,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
   semi: false,
+  endOfLine: 'auto',
 }


### PR DESCRIPTION
NOTE: I suspect the issue here is that we have mixed line endings downstream. We may want to investigate making them all conform to LF. For now, this should resolve the issue.

#### How to test:

1. Downstream, pull master and point ace at this commit (Note: it is important that you do not format)
1. In the inner ui repo, `yarn install --force`
1. Then ` yarn format -w`. You should not see any diffs.