### PR TITLE
Update spec loader to remove source map comments

### DIFF
--- a/lib/spec-loader.js
+++ b/lib/spec-loader.js
@@ -1,5 +1,7 @@
+var sourceMappingURL = require('source-map-url')
 module.exports = function (source, map) {
   this.cacheable()
+  source = sourceMappingURL.removeFrom(source)
   this.callback(
     null,
     ['describe(__filename, function () {', source, '});'].join(''),

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "script-loader": "0.7.2",
     "simple-progress-webpack-plugin": "1.1.2",
     "source-map-support": "^0.5.16",
+    "source-map-url": "0.4.0",
     "style-loader": "0.20.3",
     "stylelint": "9.5.0",
     "stylelint-config-recommended": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13406,7 +13406,7 @@ source-map-support@~0.5.12:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-url@^0.4.0:
+source-map-url@0.4.0, source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=


### PR DESCRIPTION
 - Otherwise the tests will crash.  Mostly useful for tests compiled from typescript.