### PR TITLE
Escapes % in release date command

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -29,7 +29,7 @@ const gitEnv = () => {
   const isDirty =
     exec('git status').toString().indexOf('working directory clean') === -1
 
-  const commitDate = exec('git log -1 --pretty=format:%cI').toString()
+  const commitDate = exec('git log -1 --pretty=format:\%cI').toString()
 
   return {
     __COMMIT_HASH__: JSON.stringify(commitHash),


### PR DESCRIPTION
In some environments, the output from this command is "%cI" instead of the properly formatted date.  This is believed to be due to the % character not being escaped.