### PR TITLE
Handling opening Google Chrome browsers on different platforms

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')
 const { retrieveClientConfig } = require('./webpack.config')
+const os = require('os');
 
 let chalk
 let yellow
@@ -55,7 +56,19 @@ module.exports = async ({ args, getPackage }) => {
     site = site.replace(/\/+$/, '') + '/'
     const open = (await import('open')).default
     try {
-      await open(site, { app: { name: 'google chrome' } })
+      let browserName;
+      switch (os.platform()) {
+        case 'darwin':
+          browserName = 'google chrome';
+          break;
+        case 'win32':
+          browserName = 'chrome';
+          break;
+        default:
+          browserName = 'google-chrome';
+          break;
+      }
+      await open(site, { app: { name: browserName } })
     } catch (e) {
       // Fall back to default browser if Chrome isn't available
       await open(site)


### PR DESCRIPTION
This is to fix the issue in that "yarn start" in Aus repo and DDF-UI repo fails to start up Chrome browser instance on Linux (and possibly Windows) due to the Chrome browser is named differently across platforms.

To hero locally:
1. Update package.json for Aus repo:
 "devDependencies": {
    "@connexta/ace": "file:<local_git_root_for_ace>",
2. Run "yarn install" and "yarn build" at ui/packages/intrigue.
3. Run "yarn start"