### PR TITLE
Replace WABs with resource mappings

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -85,7 +85,7 @@ program
     'extend an existing feature file',
     (val) => val.split(',')
   )
-  .option('-x, --exclude [projects]', 'exclude existing wabs', (val) =>
+  .option('-x, --exclude [projects]', 'exclude existing resource mappings', (val) =>
     val.split(',')
   )
   .action(wrap('./lib/gen-feature'))

--- a/lib/gen-feature.js
+++ b/lib/gen-feature.js
@@ -46,6 +46,20 @@ const jetty = {
   packaging: 'jar',
 }
 
+const paxWebApi = {
+  groupId: 'org.ops4j.pax.web',
+  artifactId: 'pax-web-api',
+  version: '8.0.24',
+  packaging: 'jar',
+}
+
+const paxWebWhiteboardExtender = {
+  groupId: 'org.ops4j.pax.web',
+  artifactId: 'pax-web-extender-whiteboard',
+  version: '8.0.24',
+  packaging: 'jar',
+}
+
 const extend = (files) => {
   return files.reduce((list, file) => {
     const features = fs.readFileSync(file, { encoding: 'utf8' })
@@ -64,10 +78,10 @@ const getBaseCoordinates = (args, project) => {
   }
 
   if (project.packaging === 'bundle') {
-    return [jetty, project].map(mvn)
+    return [jetty, paxWebApi, paxWebWhiteboardExtender, project].map(mvn)
   }
 
-  return [jetty].map(mvn)
+  return [jetty, paxWebApi, paxWebWhiteboardExtender].map(mvn)
 }
 
 module.exports = ({ args, getPackage, getPom }) => {

--- a/lib/mocha-headless-chrome.js
+++ b/lib/mocha-headless-chrome.js
@@ -326,4 +326,3 @@ async function runTests({
 }
 
 exports.runner = runTests
-

--- a/lib/package.js
+++ b/lib/package.js
@@ -44,47 +44,44 @@ Bundle-SymbolicName: ${pkg.name + '-wab'}
 Bundle-Vendor: ${pkg.author}
 Bundle-Version: ${version.replace('-', '.')}
 Created-By: Apache Maven Bundle Plugin
-Import-Package: org.eclipse.jetty.servlets;version="[9.2, 10.0)"
+Import-Package: org.eclipse.jetty.servlets;version="[9.2, 10.0)",org.ops4j.pax.web.extender.whiteboard.runtime;version="[8,9)",org.ops4j.pax.web.service.whiteboard;version="[8,9)"
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
-Tool: Bnd-3.3.0.201609221906
-Web-ContextPath: ${pkg['context-path']}`,
+Tool: Bnd-3.3.0.201609221906,`,
     { name: 'META-INF/MANIFEST.MF' }
   )
 
   archive.append(
-    `<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-  <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns="http://java.sun.com/xml/ns/javaee"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-           version="3.0">
+    `<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+    <!-- Map the root URL "/" -->
+    <bean id="resourceMapping"
+          class="org.ops4j.pax.web.extender.whiteboard.runtime.DefaultResourceMapping">
+    </bean>
+    
+    <service id="adminResources" ref="resourceMapping"
+             interface="org.ops4j.pax.web.service.whiteboard.ResourceMapping">
+            <service-properties>
+                <entry key="osgi.http.whiteboard.resource.pattern" value="${pkg['context-path']}/*"/>
+                <entry key="osgi.http.whiteboard.resource.prefix" value=""/>
+                <entry key="osgi.http.whiteboard.context.select" value="(osgi.http.whiteboard.context.path=/)"/>
+            </service-properties>
+    </service>
 
-      <welcome-file-list>
-          <welcome-file>index.html</welcome-file>
-      </welcome-file-list>
+    <bean id="welcomeFileMapping"
+          class="org.ops4j.pax.web.extender.whiteboard.runtime.DefaultWelcomeFileMapping">
+          <property name="redirect" value="false"/>
+          <property name="welcomeFiles">
+            <array>
+            <value>index.html</value>
+            </array>
+          </property>
+    </bean>
 
-      <context-param>
-          <param-name>org.eclipse.jetty.servlet.SessionIdPathParameterName</param-name>
-          <param-value>none</param-value>
-      </context-param>
-
-      <context-param>
-          <param-name>org.eclipse.jetty.servlet.SessionPath</param-name>
-          <param-value>/</param-value>
-      </context-param>
-
-      <filter>
-          <filter-name>GzipFilter</filter-name>
-          <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
-          <async-supported>true</async-supported>
-      </filter>
-
-      <filter-mapping>
-          <filter-name>GzipFilter</filter-name>
-          <url-pattern>/*</url-pattern>
-      </filter-mapping>
-
-  </web-app>`,
-    { name: 'WEB-INF/web.xml' }
+      <service id="welcomeFileService" ref="welcomeFileMapping" interface="org.ops4j.pax.web.service.whiteboard.WelcomeFileMapping"/>
+</blueprint>
+`,
+    { name: 'OSGI-INF/blueprint/blueprint.xml' }
   )
 
   const allPaths = (dir) => {


### PR DESCRIPTION
With the move to pax web 8 on DDF ([java 21 upgrade](https://github.com/codice/ddf/commit/8baaec85c3639e7cc2687e79fcf3a55b063be613)) there were pathing conflicts. WABs when deployed generate their own whiteboard context. So for example the ddf-ui intrigue route is /search/catalog
so api calls to /search/catalog/internal registered to the route context `/` could never be reached. So this could be worked around by creating more specific context paths, internal rerouting, or turning the WABs into resource mappings that could be registered under the same context as the other paths. The first two end up being verbose and more maintenance for any API changes. This allows us to maintain the current ace packing/application structure for these front end bundles without needing to update the projects using them. 