### PR TITLE
exclude mocha/mocha.js from source-map-loader

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -126,6 +126,7 @@ const base = ({
           fullySpecified: false,
         },
         enforce: 'pre',
+        exclude: /mocha\/mocha\.js$/,
         use: [{ loader: nodeResolve('source-map-loader'), options: {} }],
       },
       {


### PR DESCRIPTION
mocha-loader's pitch bypasses all loaders when requiring mocha.js, while start.js requires it normally through source-map-loader. Webpack hashes the loader pipeline into the module ID, so the two requires produce different IDs and webpack bundles mocha.js twice. Excluding mocha/mocha.js from source-map-loader gives both requires the same ID and lets webpack deduplicate correctly.